### PR TITLE
feat: Passport & JWT 로그인 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,8 +3,11 @@ const express = require("express");
 const dotenv = require("dotenv");
 dotenv.config();
 const morgan = require("morgan");
+const passport = require("./passport");
 const { sequelize } = require("./models");
 const seed = require("./seeders");
+
+const authRouter = require("./routes/auth");
 
 const app = express();
 app.set("port", process.env.PORT || 5000);
@@ -28,6 +31,9 @@ sequelize
 app.use(morgan("dev"));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+app.use(passport.initialize());
+
+app.use("/api/v1/auth", authRouter);
 
 app.use((req, res, next) => {
   const error = new Error(`${req.method} ${req.url} 라우터가 없습니다.`);

--- a/passport/index.js
+++ b/passport/index.js
@@ -1,0 +1,19 @@
+const passport = require("passport");
+const localStrategy = require("./localStrategy");
+const User = require("../models/User");
+
+passport.serializeUser((user, done) => {
+  console.info("___passport.serializeUser()");
+  done(null, user.email);
+});
+
+passport.deserializeUser((email, done) => {
+  console.info("___passport.deserializeUser()");
+  User.findOne({ where: { email } })
+    .then((user) => done(null, user))
+    .catch((err) => done(err));
+});
+
+passport.use(localStrategy);
+
+module.exports = passport;

--- a/passport/localStrategy.js
+++ b/passport/localStrategy.js
@@ -1,0 +1,29 @@
+const LocalStrategy = require("passport-local").Strategy;
+const bcrypt = require("bcrypt");
+const User = require("../models/User");
+
+module.exports = new LocalStrategy(
+  {
+    usernameField: "email",
+    passwordField: "password",
+  },
+  async (email, password, done) => {
+    console.info("___new LocalStrategy()");
+    try {
+      const exUser = await User.findOne({ where: { email } });
+      if (exUser) {
+        const result = await bcrypt.compare(password, exUser.password);
+        if (result) {
+          done(null, exUser);
+        } else {
+          done(null, false, { message: "비밀번호가 일치하지 않습니다." });
+        }
+      } else {
+        done(null, false, { message: "가입되지 않은 회원입니다." });
+      }
+    } catch (error) {
+      console.error(error);
+      done(error);
+    }
+  }
+);

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,40 @@
+const express = require("express");
+const jwt = require("jsonwebtoken");
+
+const passport = require("../passport/index.js");
+
+const router = express.Router();
+
+router.post("/signin", (req, res, next) => {
+  passport.authenticate("local", (authError, user, info) => {
+    console.info("___passport.authenticate()");
+    if (authError) {
+      console.error(authError);
+      return next(authError);
+    }
+    if (!user) {
+      return res
+        .status(400)
+        .json({ message: `로그인 실패 - ${info.message}`, data: {} });
+    }
+
+    console.info("___req.login()");
+    return req.login(user, { session: false }, (loginError) => {
+      if (loginError) {
+        console.error(loginError);
+        return next(loginError);
+      }
+
+      const token = jwt.sign(
+        { id: user.id, name: user.name },
+        process.env.JWT_SECRET
+      );
+      return res.json({
+        message: "로그인 성공",
+        data: { access_token: token },
+      });
+    });
+  })(req, res, next);
+});
+
+module.exports = router;


### PR DESCRIPTION
### 주요 변경 사항
<!-- 변경사항에 대한 내용 -->
- Passport와 JWT를 사용하여 로그인 기능 구현
---

### 코드 설명
<!-- 대략적인 코드설명 -->
- Passport의 `Local Strategy`로 로그인한 뒤 JWT `access_token` 토큰을 발급한다.
- 로그인이 성공했을 시 토큰을 발급하고, 로그인에 실패했을 시 실패 이유를 메시지로 반환한다.
---

### 중요도
<!-- checked : [X], unchecked : [ ] -->
- [ ] 낮음
- [ ] 보통
- [x] 높음
---

### 기타 특이사항
<!-- review시 중요하게 봐야할 내용 또는 특이사항 또는 궁금한점을 작성해주세요-->
<!-- 없으면 없음 기입 -->
- 없음

Closes #4 