### PR TITLE
feat: 중복 곡 체크 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^0.27.2",
         "bcrypt": "^5.0.1",
         "dotenv": "^16.0.1",
         "eslint": "^8.21.0",
         "express": "^4.18.1",
+        "form-data": "^4.0.0",
         "ipfs-core": "^0.14.3",
         "jsonwebtoken": "^8.5.1",
         "morgan": "^1.10.0",
@@ -1328,6 +1330,15 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3401,6 +3412,25 @@
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.1.1.tgz",
       "integrity": "sha512-S2HviLR9UyNbt8R+vU6YeQtL8RliPwez9DQEVba5MAvN3Od+RSgKUSL2+qveOMt3owIeBukKoRu2enoOck5uag=="
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -3418,16 +3448,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -8105,6 +8135,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/request/node_modules/qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
@@ -10958,6 +11001,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -12640,6 +12692,11 @@
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.1.1.tgz",
       "integrity": "sha512-S2HviLR9UyNbt8R+vU6YeQtL8RliPwez9DQEVba5MAvN3Od+RSgKUSL2+qveOMt3owIeBukKoRu2enoOck5uag=="
     },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -12654,12 +12711,12 @@
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
     },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
@@ -16336,6 +16393,16 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
         "qs": {
           "version": "6.5.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   },
   "homepage": "https://github.com/UXMUnderGraduate/22-S-Backend#readme",
   "dependencies": {
+    "axios": "^0.27.2",
     "bcrypt": "^5.0.1",
     "dotenv": "^16.0.1",
     "eslint": "^8.21.0",
     "express": "^4.18.1",
+    "form-data": "^4.0.0",
     "ipfs-core": "^0.14.3",
     "jsonwebtoken": "^8.5.1",
     "morgan": "^1.10.0",

--- a/routes/upload.js
+++ b/routes/upload.js
@@ -1,7 +1,11 @@
 const express = require("express");
-const { Op } = require("sequelize");
+const multer = require("multer");
+const axios = require("axios").default;
+const FormData = require("form-data");
 const { isLoggedIn } = require("../middlewares/auth");
 const Music = require("../models/Music");
+
+const upload = multer({ storage: multer.memoryStorage() });
 
 const router = express.Router();
 
@@ -38,5 +42,52 @@ router.delete("/:id", isLoggedIn, async (req, res) => {
     });
   }
 });
+
+router.post(
+  "/check",
+  isLoggedIn,
+  upload.single("file"),
+  async (req, res, next) => {
+    const file = req.file;
+
+    const formData = new FormData();
+    formData.append("file", Buffer.from(file.buffer), file.originalname);
+
+    // dejavu 도커 이미지에서 flask 서버 포트를 7000번으로 열어야 함
+    const result = await axios.post(
+      "http://localhost:7000/recognize",
+      formData,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+        maxBodyLength: Infinity,
+        maxContentLength: Infinity,
+      }
+    );
+
+    if (result.status !== 200) {
+      return res.status(400).json({
+        message: "중복 곡 체크 실패",
+        data: {},
+      });
+    }
+
+    let isDuplicated = false;
+    const { data } = result.data;
+    for (const song of data.results) {
+      // confidence 값이 0.3 이상인 경우 중복 곡으로 판단
+      if (song.input_confidence > 0.3) {
+        isDuplicated = true;
+        break;
+      }
+    }
+
+    return res.json({
+      message: "중복 곡 체크 성공",
+      data: { isDuplicated },
+    });
+  }
+);
 
 module.exports = router;

--- a/routes/upload.js
+++ b/routes/upload.js
@@ -77,7 +77,7 @@ router.post(
     const { data } = result.data;
     for (const song of data.results) {
       // confidence 값이 0.3 이상인 경우 중복 곡으로 판단
-      if (song.input_confidence > 0.3) {
+      if (song.input_confidence >= 0.3) {
         isDuplicated = true;
         break;
       }


### PR DESCRIPTION
### 주요 변경 사항
<!-- 변경사항에 대한 내용 -->
- `dejavu`를 활용한 중복 곡 체크 기능 구현
---

### 코드 설명
<!-- 대략적인 코드설명 -->
- 중복인지 체크할 곡의 오디오 시그니처가 `dejavu` DB에 등록된 곡의 오디오 시그니처와 30% 이상 일치할 경우 중복 곡이라 판단함
- `dejavu`가 파이썬 라이브러리이므로 `Flask` 서버를 로컬 환경에서 실행하여 `Nodejs` 서버와 통신함.
---

### 중요도
<!-- checked : [X], unchecked : [ ] -->
- [ ] 낮음
- [ ] 보통
- [x] 높음
---

### 기타 특이사항
<!-- review시 중요하게 봐야할 내용 또는 특이사항 또는 궁금한점을 작성해주세요-->
<!-- 없으면 없음 기입 -->
- `dejavu`를 `Docker`로 실행하므로 `Docker` 안에서 `Flask` 서버를 실행하고, `Docker` 컨테이너의 포트를 로컬 포트와 연결시켜주었음. 포트는 `7000`번을 사용함.

### 관련 이슈
<!-- 없으면 없음 기입 -->
- Closes #17 