### PR TITLE
feat: 블룸 필터 모듈 추가

### DIFF
--- a/bloom.json
+++ b/bloom.json
@@ -1,0 +1,1 @@
+{"type":"BloomFilter","_size":16,"_nbHashes":3,"_filter":{"size":16,"content":"ASg="},"_seed":78187493520}

--- a/modules/bloom-filter.js
+++ b/modules/bloom-filter.js
@@ -1,0 +1,41 @@
+const fs = require("fs");
+const { BloomFilter } = require("bloom-filters");
+
+const loadOrCreateFilter = () => {
+  let filter;
+  try {
+    const data = fs.readFileSync("./bloom.json");
+    filter = BloomFilter.fromJSON(JSON.parse(data));
+  } catch (err) {
+    console.error(err);
+    filter = new BloomFilter(16, 3);
+  }
+
+  return filter;
+};
+
+const saveFilter = (filter) => {
+  try {
+    const exported = filter.saveAsJSON();
+    fs.writeFileSync("./bloom.json", JSON.stringify(exported));
+    return true;
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
+};
+
+module.exports = class ClassicBloomFilter {
+  constructor() {
+    this.filter = loadOrCreateFilter();
+  }
+
+  add(word) {
+    this.filter.add(word);
+    return saveFilter(this.filter);
+  }
+
+  has(word) {
+    return this.filter.has(word);
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^0.27.2",
         "bcrypt": "^5.0.1",
+        "bloom-filters": "^3.0.0",
         "dotenv": "^16.0.1",
         "eslint": "^8.21.0",
         "express": "^4.18.1",
@@ -1353,6 +1354,14 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1482,6 +1491,30 @@
         "it-pushable": "^1.4.2",
         "multiformats": "^9.1.0"
       }
+    },
+    "node_modules/bloom-filters": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bloom-filters/-/bloom-filters-3.0.0.tgz",
+      "integrity": "sha512-DBDgLkYokKS5NA5y8P9fuTavKQCkleAP39yqpW/5Nab/vwzHv+wOPRM/yDAStghARDleyRI4orW91uuxj48LKQ==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2",
+        "is-buffer": "^2.0.5",
+        "lodash": "^4.17.15",
+        "lodash.eq": "^4.0.0",
+        "lodash.indexof": "^4.0.5",
+        "long": "^5.2.0",
+        "reflect-metadata": "^0.1.13",
+        "seedrandom": "^3.0.5",
+        "xxhashjs": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bloom-filters/node_modules/long": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
@@ -2161,6 +2194,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw=="
     },
     "node_modules/d": {
       "version": "1.0.1",
@@ -6298,10 +6336,20 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.eq": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.eq/-/lodash.eq-4.0.0.tgz",
+      "integrity": "sha512-vbrJpXL6kQNG6TkInxX12DZRfuYVllSxhwYqjYB78g2zF3UI15nFO/0AgmZnZRnaQ38sZtjCiVjGr2rnKt4v0g=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.indexof": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/lodash.indexof/-/lodash.indexof-4.0.5.tgz",
+      "integrity": "sha512-t9wLWMQsawdVmf6/IcAgVGqAJkNzYVcn4BHYZKTPW//l7N5Oq7Bq138BaVk19agcsPZePcidSgTTw4NqS1nUAw=="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -8077,6 +8125,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -8346,6 +8399,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/semver": {
       "version": "5.7.1",
@@ -10002,6 +10060,14 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/xxhashjs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
+      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
+      "dependencies": {
+        "cuint": "^0.2.2"
+      }
+    },
     "node_modules/yaeti": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
@@ -11023,6 +11089,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -11128,6 +11199,29 @@
         "it-drain": "^1.0.1",
         "it-pushable": "^1.4.2",
         "multiformats": "^9.1.0"
+      }
+    },
+    "bloom-filters": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bloom-filters/-/bloom-filters-3.0.0.tgz",
+      "integrity": "sha512-DBDgLkYokKS5NA5y8P9fuTavKQCkleAP39yqpW/5Nab/vwzHv+wOPRM/yDAStghARDleyRI4orW91uuxj48LKQ==",
+      "requires": {
+        "base64-arraybuffer": "^1.0.2",
+        "is-buffer": "^2.0.5",
+        "lodash": "^4.17.15",
+        "lodash.eq": "^4.0.0",
+        "lodash.indexof": "^4.0.5",
+        "long": "^5.2.0",
+        "reflect-metadata": "^0.1.13",
+        "seedrandom": "^3.0.5",
+        "xxhashjs": "^0.2.2"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+          "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+        }
       }
     },
     "bluebird": {
@@ -11683,6 +11777,11 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw=="
     },
     "d": {
       "version": "1.0.1",
@@ -14985,10 +15084,20 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.eq": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.eq/-/lodash.eq-4.0.0.tgz",
+      "integrity": "sha512-vbrJpXL6kQNG6TkInxX12DZRfuYVllSxhwYqjYB78g2zF3UI15nFO/0AgmZnZRnaQ38sZtjCiVjGr2rnKt4v0g=="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.indexof": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/lodash.indexof/-/lodash.indexof-4.0.5.tgz",
+      "integrity": "sha512-t9wLWMQsawdVmf6/IcAgVGqAJkNzYVcn4BHYZKTPW//l7N5Oq7Bq138BaVk19agcsPZePcidSgTTw4NqS1nUAw=="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
@@ -16351,6 +16460,11 @@
         }
       }
     },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
     "regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -16533,6 +16647,11 @@
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       }
+    },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "semver": {
       "version": "5.7.1",
@@ -17813,6 +17932,14 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "xxhashjs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
+      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
+      "requires": {
+        "cuint": "^0.2.2"
+      }
     },
     "yaeti": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "bcrypt": "^5.0.1",
+    "bloom-filters": "^3.0.0",
     "dotenv": "^16.0.1",
     "eslint": "^8.21.0",
     "express": "^4.18.1",


### PR DESCRIPTION
### 주요 변경 사항
<!-- 변경사항에 대한 내용 -->
- [`bloom-filters`](https://github.com/Callidon/bloom-filters) npm 모듈을 활용한 블룸 필터 모듈 추가
---

### 코드 설명
<!-- 대략적인 코드설명 -->
- `bloom.json` 파일이 프로젝트 폴더에 존재하지 않으면 필터 생성, 존재한다면 해당 파일로부터 필터를 로드함.
- 블룸필터 객체는 `16`개의 비트와 `3`개의 해시함수로 만들어짐.
- `add` 메서드는 블룸필터에 `word`를 저장하고 `bloom.json` 파일로 `export`함.
- `has` 메서드는 블룸필터에서 `word`가 있는지 검색함.
---

### 중요도
<!-- checked : [X], unchecked : [ ] -->
- [ ] 낮음
- [ ] 보통
- [x] 높음
---

### 기타 특이사항
<!-- review시 중요하게 봐야할 내용 또는 특이사항 또는 궁금한점을 작성해주세요-->
<!-- 없으면 없음 기입 -->
- 원래 모듈의 블룸필터 객체가 `BloomFilter`이므로, 모듈화한 클래스의 이름을 `ClassicBloomFilter`라고 하였음.
- 블룸필터의 해시함수 시드는 기본값인 `0x1234567890`임.

### 관련 이슈
<!-- 없으면 없음 기입 -->
- Closes #37 